### PR TITLE
fix: Update lsp range actions keymap binding

### DIFF
--- a/.config/nvim/fnl/config/plugin/lspconfig.fnl
+++ b/.config/nvim/fnl/config/plugin/lspconfig.fnl
@@ -41,7 +41,7 @@
                     (nvim.buf_set_keymap bufnr :n :<leader>lk "<cmd>lua vim.lsp.diagnostic.goto_prev()<CR>" {:noremap true})
                     ;telescope
                     (nvim.buf_set_keymap bufnr :n :<leader>la ":lua require('telescope.builtin').lsp_code_actions(require('telescope.themes').get_cursor())<cr>" {:noremap true})
-                    (nvim.buf_set_keymap bufnr :v :<leader>la ":lua require('telescope.builtin').lsp_range_code_actions(require('telescope.themes').get_cursor())<cr>" {:noremap true})
+                    (nvim.buf_set_keymap bufnr :v :<leader>la ":'<,'>:Telescope lsp_range_code_actions theme=cursor<cr>" {:noremap true})
                     (nvim.buf_set_keymap bufnr :n :<leader>lw ":lua require('telescope.builtin').lsp_workspace_diagnostics()<cr>" {:noremap true})
                     (nvim.buf_set_keymap bufnr :n :<leader>lr ":lua require('telescope.builtin').lsp_references()<cr>" {:noremap true})
                     (nvim.buf_set_keymap bufnr :n :<leader>li ":lua require('telescope.builtin').lsp_implementations()<cr>" {:noremap true})))]


### PR DESCRIPTION
There seems to be an issue with the lsp range code actions lua api from
Telescope. Keybinding was updated to use the `'<,'>:Telescope` notation.

For reference, that's the error I was getting:
![image](https://user-images.githubusercontent.com/49727703/145070153-dfef465f-4b44-4741-a7c3-c648cca6164a.png)