### PR TITLE
fix: Restore lsp sign default colors

### DIFF
--- a/.config/nvim/fnl/config/plugin/lspconfig.fnl
+++ b/.config/nvim/fnl/config/plugin/lspconfig.fnl
@@ -4,10 +4,20 @@
              cmplsp cmp_nvim_lsp}})
 
 ;symbols to show for lsp diagnostics
-(vim.fn.sign_define "LspDiagnosticsSignError" {:text "" :texthl "LspDiagnosticsSignError"})
-(vim.fn.sign_define "LspDiagnosticsSignWarning" {:text "" :texthl "LspDiagnosticsSignWarning"})
-(vim.fn.sign_define "LspDiagnosticsSignInformation" {:text "" :texthl "LspDiagnosticsSignInformation"})
-(vim.fn.sign_define "LspDiagnosticsSignHint" {:text "" :texthl "LspDiagnosticsSignHint"})
+(defn define-signs
+  [prefix]
+  (let [error (.. prefix "SignError")
+        warn  (.. prefix "SignWarn")
+        info  (.. prefix "SignInfo")
+        hint  (.. prefix "SignHint")]
+  (vim.fn.sign_define error {:text "x" :texthl error})
+  (vim.fn.sign_define warn  {:text "!" :texthl warn})
+  (vim.fn.sign_define info  {:text "i" :texthl info})
+  (vim.fn.sign_define hint  {:text "?" :texthl hint})))
+
+(if (= (nvim.fn.has "nvim-0.6") 1)
+  (define-signs "Diagnostic")
+  (define-signs "LspDiagnostics"))
 
 ;server features
 (let [handlers {"textDocument/publishDiagnostics"

--- a/.config/nvim/fnl/config/plugin/lspconfig.fnl
+++ b/.config/nvim/fnl/config/plugin/lspconfig.fnl
@@ -4,10 +4,10 @@
              cmplsp cmp_nvim_lsp}})
 
 ;symbols to show for lsp diagnostics
-(vim.fn.sign_define "LspDiagnosticsSignError" {:text ""})
-(vim.fn.sign_define "LspDiagnosticsSignWarning" {:text ""})
-(vim.fn.sign_define "LspDiagnosticsSignInformation" {:text ""})
-(vim.fn.sign_define "LspDiagnosticsSignHint" {:text ""})
+(vim.fn.sign_define "LspDiagnosticsSignError" {:text "" :texthl "LspDiagnosticsSignError"})
+(vim.fn.sign_define "LspDiagnosticsSignWarning" {:text "" :texthl "LspDiagnosticsSignWarning"})
+(vim.fn.sign_define "LspDiagnosticsSignInformation" {:text "" :texthl "LspDiagnosticsSignInformation"})
+(vim.fn.sign_define "LspDiagnosticsSignHint" {:text "" :texthl "LspDiagnosticsSignHint"})
 
 ;server features
 (let [handlers {"textDocument/publishDiagnostics"


### PR DESCRIPTION
I noticed the lsp signs weren't being coloured.
This changeset should restore their default color, that's how it looks in my setup now:
![image](https://user-images.githubusercontent.com/49727703/145372667-b65d9497-35fb-414b-8b4b-2b173c326d7f.png)