### PR TITLE
Fixed syntactic error

### DIFF
--- a/.config/nvim/fnl/config/init.fnl
+++ b/.config/nvim/fnl/config/init.fnl
@@ -9,7 +9,7 @@
 (set nvim.g.mapleader " ")
 (set nvim.g.maplocalleader ",")
 
-:;; Spacemacs style leader mappings.
+;; Spacemacs style leader mappings.
 (nvim.set_keymap :n :<leader>wm ":tab sp<cr>" {:noremap true})
 ;; new buffer
 (nvim.set_keymap :n :<leader>bn ":bn" {:noremap true})


### PR DESCRIPTION
# Syntactic error
I've cloned the repo on may local machine. Then followed the guidelines in the Readme file to have the setup up and running. But it wouldn't work due to a syntactic error. Which I traced to a comment line start character. This PR fixes it.

## Doubts
Though the error should be present for everyone that have pulled the latest main. I am not sure why a PR hasn't been opened yet. Am I missing something? 